### PR TITLE
Update package.json to point to latest @vscode/test-electron

### DIFF
--- a/scripts/get_default_keybindings/package-lock.json
+++ b/scripts/get_default_keybindings/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "-",
 			"version": "0.1.0",
 			"devDependencies": {
-				"@vscode/test-electron": "^2.3.4"
+				"@vscode/test-electron": "^2.4.0"
 			},
 			"engines": {
 				"vscode": "^1.66.0"

--- a/scripts/get_default_keybindings/package.json
+++ b/scripts/get_default_keybindings/package.json
@@ -9,6 +9,6 @@
 		"start": "node ./main.js"
 	},
 	"devDependencies": {
-		"@vscode/test-electron": "^2.3.4"
+		"@vscode/test-electron": "^2.4.0"
 	}
 }


### PR DESCRIPTION
This PR fixes package.json and package-lock.json to point to the latest `@vscode/test-electron`.

However, curiously, the new version 2.4.0 is the version that dependabot has already done catching up to in #118.

Anyway, if this change works successfully, I will merge it.