### PR TITLE
Make empty directory paths shorter

### DIFF
--- a/scripts/get_default_keybindings/main.js
+++ b/scripts/get_default_keybindings/main.js
@@ -6,6 +6,8 @@ const { runTests } = require('@vscode/test-electron');
 async function main() {
     try {
         // Make two empty directories to use to launch VS Code with the cleanest possible profile.
+        // The '../../' part is intended to shorten the path and was needed as a workaround.
+        // See: https://github.com/codebling/vs-code-default-keybindings/pull/222
         const emptyDir1 = path.resolve(__dirname, '../../empty1');
         const emptyDir2 = path.resolve(__dirname, '../../empty2');
         await fsPromises.mkdir(emptyDir1, { recursive: true });

--- a/scripts/get_default_keybindings/main.js
+++ b/scripts/get_default_keybindings/main.js
@@ -6,8 +6,8 @@ const { runTests } = require('@vscode/test-electron');
 async function main() {
     try {
         // Make two empty directories to use to launch VS Code with the cleanest possible profile.
-        const emptyDir1 = path.resolve(__dirname, 'empty1');
-        const emptyDir2 = path.resolve(__dirname, 'empty2');
+        const emptyDir1 = path.resolve(__dirname, '../../empty1');
+        const emptyDir2 = path.resolve(__dirname, '../../empty2');
         await fsPromises.mkdir(emptyDir1, { recursive: true });
         await fsPromises.mkdir(emptyDir2, { recursive: true });
 


### PR DESCRIPTION
This PR is an attempt to fix the recent CI failures on macOS.

Failure logs look always contain the following line just before the error.
```
WARNING: IPC handle "/Users/runner/work/vs-code-default-keybindings/vs-code-default-keybindings/scripts/get_default_keybindings/empty2/1.12-main.sock" is longer than 103 chars, try a shorter --user-data-dir
```
So, let's see if shorter paths fix the error.
